### PR TITLE
Qualcomm AI Engine Direct - Enable ConvHMX and FoldReLU options.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -37,6 +37,10 @@ struct LiteRtQualcommOptionsT {
       kLiteRtQualcommHtpPerformanceModeDefault;
   std::vector<std::int32_t> dump_tensor_ids;
   std::string ir_json_dir;
+  std::uint32_t vtcm_size = 0;
+  std::uint32_t num_hvx_threads = 0;
+  LiteRtQualcommOptionsOptimizationLevel optimization_level =
+      kHtpOptimizeForInferenceO3;
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -265,6 +269,74 @@ LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
   }
 
   *ir_json_dir = options->ir_json_dir.c_str();
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetVtcmSize(LiteRtQualcommOptions options,
+                                              std::uint32_t vtcm_size) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->vtcm_size = vtcm_size;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetVtcmSize(LiteRtQualcommOptions options,
+                                              std::uint32_t* vtcm_size) {
+  if (options == nullptr || vtcm_size == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *vtcm_size = options->vtcm_size;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetNumHvxThreads(
+    LiteRtQualcommOptions options, std::uint32_t num_hvx_threads) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->num_hvx_threads = num_hvx_threads;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetNumHvxThreads(
+    LiteRtQualcommOptions options, std::uint32_t* num_hvx_threads) {
+  if (options == nullptr || num_hvx_threads == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *num_hvx_threads = options->num_hvx_threads;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel optimization_level) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->optimization_level = optimization_level;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel* optimization_level) {
+  if (options == nullptr || optimization_level == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *optimization_level = options->optimization_level;
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -33,6 +33,8 @@ struct LiteRtQualcommOptionsT {
   bool use_htp_preference = false;
   bool use_qint16_as_quint16 = false;
   bool enable_weight_sharing = false;
+  bool use_conv_hmx = false;
+  bool use_fold_relu = false;
   LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode =
       kLiteRtQualcommHtpPerformanceModeDefault;
   std::vector<std::int32_t> dump_tensor_ids;
@@ -200,6 +202,50 @@ LiteRtStatus LiteRtQualcommOptionsGetDumpTensorIds(
   }
   *ids = options->dump_tensor_ids.data();
   *number_of_ids = options->dump_tensor_ids.size();
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool use_conv_hmx) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_conv_hmx = use_conv_hmx;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool* use_conv_hmx) {
+  if (use_conv_hmx == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_conv_hmx = options->use_conv_hmx;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool use_fold_relu) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_fold_relu = use_fold_relu;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool* use_fold_relu) {
+  if (use_fold_relu == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_fold_relu = options->use_fold_relu;
+
   return kLiteRtStatusOk;
 }
 

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -162,6 +162,32 @@ LiteRtStatus LiteRtQualcommOptionsSetIrJsonDir(LiteRtQualcommOptions options,
 LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
                                                const char** ir_json_dir);
 
+LiteRtStatus LiteRtQualcommOptionsSetVtcmSize(LiteRtQualcommOptions options,
+                                              uint32_t vtcm_size);
+
+LiteRtStatus LiteRtQualcommOptionsGetVtcmSize(LiteRtQualcommOptions options,
+                                              uint32_t* vtcm_size);
+
+LiteRtStatus LiteRtQualcommOptionsSetNumHvxThreads(
+    LiteRtQualcommOptions options, uint32_t num_hvx_threads);
+
+LiteRtStatus LiteRtQualcommOptionsGetNumHvxThreads(
+    LiteRtQualcommOptions options, uint32_t* num_hvx_threads);
+
+typedef enum LiteRtQualcommOptionsOptimizationLevel {
+  kHtpOptimizeForInference = 0,
+  kHtpOptimizeForPrepare,
+  kHtpOptimizeForInferenceO3,
+} LiteRtQualcommOptionsOptimizationLevel;
+
+LiteRtStatus LiteRtQualcommOptionsSetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel optimization_level);
+
+LiteRtStatus LiteRtQualcommOptionsGetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel* optimization_level);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -109,6 +109,24 @@ LiteRtStatus LiteRtQualcommOptionsSetDumpTensorIds(
 LiteRtStatus LiteRtQualcommOptionsGetDumpTensorIds(
     LiteRtQualcommOptions options, int32_t** ids, uint32_t* number_of_ids);
 
+// Run Convolution operations with short depth and/or unsymmetric weights using
+// HMX instructions.
+
+LiteRtStatus LiteRtQualcommOptionsSetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool use_conv_hmx);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool* use_conv_hmx);
+
+// For any graph where a Convolution or Convolution like operation is followed
+// by Relu or ReluMinMax, the relu is folded into the Convolution operation.
+
+LiteRtStatus LiteRtQualcommOptionsSetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool use_fold_relu);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool* use_fold_relu);
+
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
 // htp_performance_mode

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -245,6 +245,40 @@ TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, UseConvHMX) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetUseConvHMX(qualcomm_options, true));
+
+  bool use_conv_hmx;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetUseConvHMX(qualcomm_options, &use_conv_hmx));
+  EXPECT_TRUE(use_conv_hmx);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, UseFoldReLU) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetUseFoldReLU(qualcomm_options, true));
+
+  bool use_fold_relu;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetUseFoldReLU(qualcomm_options, &use_fold_relu));
+  EXPECT_TRUE(use_fold_relu);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(QualcommOptionsTest, CppApi) {
   auto options = QualcommOptions::Create();
   ASSERT_TRUE(options);
@@ -298,6 +332,14 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForInferenceO3);
   options->SetOptimizationLevel(kHtpOptimizeForPrepare);
   EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForPrepare);
+
+  EXPECT_FALSE(options->GetUseConvHMX());
+  options->SetUseConvHMX(true);
+  EXPECT_TRUE(options->GetUseConvHMX());
+
+  EXPECT_FALSE(options->GetUseFoldReLU());
+  options->SetUseFoldReLU(true);
+  EXPECT_TRUE(options->GetUseFoldReLU());
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -170,6 +170,58 @@ TEST(LiteRtQualcommOptionsTest, IrJsonDir) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, VtcmSize) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetVtcmSize(qualcomm_options, 4));
+
+  uint32_t vtcm_size;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetVtcmSize(qualcomm_options, &vtcm_size));
+  EXPECT_EQ(vtcm_size, 4);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, HvxThread) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetNumHvxThreads(qualcomm_options, 4));
+
+  uint32_t num_hvx_threads;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetNumHvxThreads(qualcomm_options,
+                                                         &num_hvx_threads));
+  EXPECT_EQ(num_hvx_threads, 4);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, OptimizationLevel) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetOptimizationLevel(
+      qualcomm_options, kHtpOptimizeForPrepare));
+
+  LiteRtQualcommOptionsOptimizationLevel optimization_level;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetOptimizationLevel(
+      qualcomm_options, &optimization_level));
+  EXPECT_EQ(optimization_level, kHtpOptimizeForPrepare);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
@@ -234,6 +286,18 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetIrJsonDir(), "");
   options->SetIrJsonDir("tmp");
   EXPECT_EQ(options->GetIrJsonDir(), "tmp");
+
+  EXPECT_EQ(options->GetVtcmSize(), 0);
+  options->SetVtcmSize(4);
+  EXPECT_EQ(options->GetVtcmSize(), 4);
+
+  EXPECT_EQ(options->GetNumHvxThreads(), 0);
+  options->SetNumHvxThreads(4);
+  EXPECT_EQ(options->GetNumHvxThreads(), 4);
+
+  EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForInferenceO3);
+  options->SetOptimizationLevel(kHtpOptimizeForPrepare);
+  EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForPrepare);
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -183,6 +183,28 @@ LiteRtQualcommOptionsOptimizationLevel QualcommOptions::GetOptimizationLevel() {
   return optimization_level;
 }
 
+void QualcommOptions::SetUseConvHMX(bool use_conv_hmx) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseConvHMX, Data(), use_conv_hmx);
+}
+
+bool QualcommOptions::GetUseConvHMX() {
+  bool use_conv_hmx;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseConvHMX, Data(), &use_conv_hmx);
+  return use_conv_hmx;
+}
+
+void QualcommOptions::SetUseFoldReLU(bool use_fold_relu) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseFoldReLU, Data(),
+                     use_fold_relu);
+}
+
+bool QualcommOptions::GetUseFoldReLU() {
+  bool use_fold_relu;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseFoldReLU, Data(),
+                     &use_fold_relu);
+  return use_fold_relu;
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -148,6 +148,41 @@ absl::string_view QualcommOptions::GetIrJsonDir() {
   return absl::string_view(ir_json_dir);
 }
 
+void QualcommOptions::SetVtcmSize(std::uint32_t vtcm_size) {
+  internal::AssertOk(LiteRtQualcommOptionsSetVtcmSize, Data(), vtcm_size);
+}
+
+std::uint32_t QualcommOptions::GetVtcmSize() {
+  std::uint32_t vtcm_size;
+  internal::AssertOk(LiteRtQualcommOptionsGetVtcmSize, Data(), &vtcm_size);
+  return vtcm_size;
+}
+
+void QualcommOptions::SetNumHvxThreads(std::uint32_t num_hvx_threads) {
+  internal::AssertOk(LiteRtQualcommOptionsSetNumHvxThreads, Data(),
+                     num_hvx_threads);
+}
+
+std::uint32_t QualcommOptions::GetNumHvxThreads() {
+  std::uint32_t num_hvx_threads;
+  internal::AssertOk(LiteRtQualcommOptionsGetNumHvxThreads, Data(),
+                     &num_hvx_threads);
+  return num_hvx_threads;
+}
+
+void QualcommOptions::SetOptimizationLevel(
+    LiteRtQualcommOptionsOptimizationLevel optimization_level) {
+  internal::AssertOk(LiteRtQualcommOptionsSetOptimizationLevel, Data(),
+                     optimization_level);
+}
+
+LiteRtQualcommOptionsOptimizationLevel QualcommOptions::GetOptimizationLevel() {
+  LiteRtQualcommOptionsOptimizationLevel optimization_level;
+  internal::AssertOk(LiteRtQualcommOptionsGetOptimizationLevel, Data(),
+                     &optimization_level);
+  return optimization_level;
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -57,6 +57,12 @@ class QualcommOptions : public OpaqueOptions {
   void SetEnableWeightSharing(bool weight_sharing_enabled);
   bool GetEnableWeightSharing();
 
+  void SetUseConvHMX(bool use_conv_hmx);
+  bool GetUseConvHMX();
+
+  void SetUseFoldReLU(bool use_fold_relu);
+  bool GetUseFoldReLU();
+
   void SetProfiling(LiteRtQualcommOptionsProfiling profiling);
   LiteRtQualcommOptionsProfiling GetProfiling();
 

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -66,6 +66,16 @@ class QualcommOptions : public OpaqueOptions {
   void SetIrJsonDir(const std::string& ir_json_dir);
   absl::string_view GetIrJsonDir();
 
+  void SetVtcmSize(std::uint32_t vtcm_size);
+  std::uint32_t GetVtcmSize();
+
+  void SetNumHvxThreads(std::uint32_t num_hvx_threads);
+  std::uint32_t GetNumHvxThreads();
+
+  void SetOptimizationLevel(
+      LiteRtQualcommOptionsOptimizationLevel optimization_level);
+  LiteRtQualcommOptionsOptimizationLevel GetOptimizationLevel();
+
  private:
   LiteRtQualcommOptions Data() const;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -215,6 +215,47 @@ ABSL_FLAG(
     "Qnn IR JSON directory. If provided, you can obtain Qnn IR in Qnn JSON "
     "format.");
 
+ABSL_FLAG(uint32_t, qualcomm_vtcm_size, 0,
+          "The vtcm size of the target device. If this option is set to 0, the "
+          "max size of vtcm size will be used.");
+
+ABSL_FLAG(uint32_t, qualcomm_num_hvx_thread, 0,
+          "The number of hvx threads for the target device. If this option is "
+          "set to 0, the max number of hvx threads will be used.");
+
+ABSL_FLAG(LiteRtQualcommOptionsOptimizationLevel, qualcomm_optimization_level,
+          kHtpOptimizeForInferenceO3, "QNN optimization level");
+
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsOptimizationLevel* options,
+                   std::string* error) {
+  if (text == "O1") {
+    *options = kHtpOptimizeForInference;
+    return true;
+  }
+  if (text == "O2") {
+    *options = kHtpOptimizeForPrepare;
+    return true;
+  }
+  if (text == "O3") {
+    *options = kHtpOptimizeForInferenceO3;
+    return true;
+  }
+  *error = "Unknown optimization level";
+  return false;
+}
+
+std::string AbslUnparseFlag(LiteRtQualcommOptionsOptimizationLevel options) {
+  switch (options) {
+    case kHtpOptimizeForInference:
+      return "O1";
+    case kHtpOptimizeForPrepare:
+      return "O2";
+    case kHtpOptimizeForInferenceO3:
+      return "O3";
+  }
+}
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -253,6 +294,16 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
 
   const std::string ir_json_dir = absl::GetFlag(FLAGS_qualcomm_ir_json_dir);
   opts.SetIrJsonDir(ir_json_dir);
+
+  const auto vtcm_size = absl::GetFlag(FLAGS_qualcomm_vtcm_size);
+  opts.SetVtcmSize(vtcm_size);
+
+  const auto num_hvx_threads = absl::GetFlag(FLAGS_qualcomm_num_hvx_thread);
+  opts.SetNumHvxThreads(num_hvx_threads);
+
+  const auto optimization_level =
+      absl::GetFlag(FLAGS_qualcomm_optimization_level);
+  opts.SetOptimizationLevel(optimization_level);
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -256,6 +256,14 @@ std::string AbslUnparseFlag(LiteRtQualcommOptionsOptimizationLevel options) {
   }
 }
 
+ABSL_FLAG(bool, qualcomm_use_conv_hmx, false,
+          "Whether to use HMX for convolution operation with short depth "
+          "and/or unsymmetrice weights.");
+
+ABSL_FLAG(bool, qualcomm_use_fold_relu, false,
+          "Whether to fold relu to convolution operation if the convolution "
+          "operation is followed by relu.");
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -304,6 +312,12 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
   const auto optimization_level =
       absl::GetFlag(FLAGS_qualcomm_optimization_level);
   opts.SetOptimizationLevel(optimization_level);
+
+  const auto use_conv_hmx = absl::GetFlag(FLAGS_qualcomm_use_conv_hmx);
+  opts.SetUseConvHMX(use_conv_hmx);
+
+  const auto use_fold_relu = absl::GetFlag(FLAGS_qualcomm_use_fold_relu);
+  opts.SetUseFoldReLU(use_fold_relu);
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -62,6 +62,10 @@ bool AbslParseFlag(absl::string_view text,
 std::string AbslUnparseFlag(
     LiteRtQualcommOptionsOptimizationLevel optimization_level);
 
+ABSL_DECLARE_FLAG(bool, qualcomm_use_conv_hmx);
+
+ABSL_DECLARE_FLAG(bool, qualcomm_use_fold_relu);
+
 #endif
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -50,6 +50,18 @@ ABSL_DECLARE_FLAG(std::vector<std::string>, qualcomm_dump_tensor_ids);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);
 
+ABSL_DECLARE_FLAG(uint32_t, qualcomm_vtcm_size);
+
+ABSL_DECLARE_FLAG(uint32_t, qualcomm_num_hvx_thread);
+
+ABSL_DECLARE_FLAG(LiteRtQualcommOptionsOptimizationLevel,
+                  qualcomm_optimization_level);
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsOptimizationLevel* optimization_level,
+                   std::string* error);
+std::string AbslUnparseFlag(
+    LiteRtQualcommOptionsOptimizationLevel optimization_level);
+
 #endif
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -241,6 +241,38 @@ TEST(ProfilingTest, Parse) {
   }
 }
 
+TEST(OptimizationLevelTest, Parse) {
+  std::string error;
+  LiteRtQualcommOptionsOptimizationLevel value;
+
+  {
+    static constexpr absl::string_view kOptimizationLevel = "O1";
+    static constexpr LiteRtQualcommOptionsOptimizationLevel
+        kOptimizationLevelEnum = kHtpOptimizeForInference;
+    EXPECT_TRUE(AbslParseFlag(kOptimizationLevel, &value, &error));
+    EXPECT_EQ(value, kOptimizationLevelEnum);
+    EXPECT_EQ(kOptimizationLevel, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kOptimizationLevel = "O2";
+    static constexpr LiteRtQualcommOptionsOptimizationLevel
+        kOptimizationLevelEnum = kHtpOptimizeForPrepare;
+    EXPECT_TRUE(AbslParseFlag(kOptimizationLevel, &value, &error));
+    EXPECT_EQ(value, kOptimizationLevelEnum);
+    EXPECT_EQ(kOptimizationLevel, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kOptimizationLevel = "O3";
+    static constexpr LiteRtQualcommOptionsOptimizationLevel
+        kOptimizationLevelEnum = kHtpOptimizeForInferenceO3;
+    EXPECT_TRUE(AbslParseFlag(kOptimizationLevel, &value, &error));
+    EXPECT_EQ(value, kOptimizationLevelEnum);
+    EXPECT_EQ(kOptimizationLevel, AbslUnparseFlag(value));
+  }
+}
+
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   Expected<QualcommOptions> options = QualcommOptionsFromFlags();
   ASSERT_TRUE(options.HasValue());
@@ -252,6 +284,9 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
             kLiteRtQualcommHtpPerformanceModeBurst);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());
+  EXPECT_EQ(options.Value().GetVtcmSize(), 0);
+  EXPECT_EQ(options.Value().GetNumHvxThreads(), 0);
+  EXPECT_EQ(options.Value().GetOptimizationLevel(), kHtpOptimizeForInferenceO3);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -115,6 +115,10 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());
+  qnn_options.SetVtcmSize(qualcomm_options.GetVtcmSize());
+  qnn_options.SetNumHvxThreads(qualcomm_options.GetNumHvxThreads());
+  qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(
+      qualcomm_options.GetOptimizationLevel()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -112,6 +112,8 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetUseHtpPreference(qualcomm_options.GetUseHtpPreference());
   qnn_options.SetUseQint16AsQuint16(qualcomm_options.GetUseQint16AsQuint16());
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
+  qnn_options.SetUseConvHMX(qualcomm_options.GetUseConvHMX());
+  qnn_options.SetUseFoldReLU(qualcomm_options.GetUseFoldReLU());
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -36,9 +36,9 @@ namespace litert::qnn {
 
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 5> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 6> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 6> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 6> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 7> result;
 
   // QNN suggest always enable relax precision.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
@@ -61,18 +61,24 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
   graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[3].option =
       QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
-  graph_custom_configs[3].foldReluActivationIntoConvOff = true;
+  graph_custom_configs[3].foldReluActivationIntoConvOff =
+      !options.GetUseFoldReLU();
+  // ConvHMX Off
+  graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[4].option =
+      QNN_HTP_GRAPH_CONFIG_OPTION_SHORT_DEPTH_CONV_ON_HMX_OFF;
+  graph_custom_configs[4].shortDepthConvOnHmxOff = !options.GetUseConvHMX();
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
   if (has_hvx) {
-    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[4].option =
+    graph_custom_configs[5] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[5].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[5].numHvxThreads = options.GetNumHvxThreads();
   }
 
-  size_t num_config = has_hvx ? 5 : 4;
+  size_t num_config = has_hvx ? 6 : 5;
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
@@ -86,9 +92,9 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
 
 inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 4> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 4> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 5> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 5> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 6> result;
   // Default use O3 for now.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
@@ -107,18 +113,24 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
   graph_custom_configs[2] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[2].option =
       QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
-  graph_custom_configs[2].foldReluActivationIntoConvOff = true;
+  graph_custom_configs[2].foldReluActivationIntoConvOff =
+      !options.GetUseFoldReLU();
+  // ConvHMX Off
+  graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[3].option =
+      QNN_HTP_GRAPH_CONFIG_OPTION_SHORT_DEPTH_CONV_ON_HMX_OFF;
+  graph_custom_configs[3].shortDepthConvOnHmxOff = !options.GetUseConvHMX();
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
   if (has_hvx) {
-    graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[3].option =
+    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[4].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[3].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
   }
 
-  size_t num_config = has_hvx ? 4 : 3;
+  size_t num_config = has_hvx ? 5 : 4;
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -34,8 +34,12 @@
 
 namespace litert::qnn {
 
-inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs() {
-  static std::array<QnnHtpGraph_CustomConfig_t, 4> graph_custom_configs;
+inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
+    const ::qnn::Options& options) {
+  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 5> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 6> result;
+
   // QNN suggest always enable relax precision.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION;
@@ -46,85 +50,92 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs() {
   graph_custom_configs[1].optimizationOption.type =
       QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
   // Change to 2 if you want to use O2 (default).
-  graph_custom_configs[1].optimizationOption.floatValue = 3;
+  graph_custom_configs[1].optimizationOption.floatValue =
+      static_cast<float>(options.GetOptimizationLevel());
   // VTCM
   graph_custom_configs[2] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[2].option = QNN_HTP_GRAPH_CONFIG_OPTION_VTCM_SIZE;
-  graph_custom_configs[2].vtcmSizeInMB = QNN_HTP_GRAPH_CONFIG_OPTION_MAX;
+  // The default value is 0 which means the MAX value
+  graph_custom_configs[2].vtcmSizeInMB = options.GetVtcmSize();
   // FoldRelu Off
   graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[3].option =
       QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
   graph_custom_configs[3].foldReluActivationIntoConvOff = true;
 
-  static std::array<QnnGraph_Config_t, 4> graph_configs;
-  graph_configs[0] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[0].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[0].customConfig = &graph_custom_configs[0];
+  // Hvx Thread
+  bool has_hvx = options.GetNumHvxThreads() != 0;
+  if (has_hvx) {
+    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[4].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
+    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
+  }
 
-  graph_configs[1] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[1].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[1].customConfig = &graph_custom_configs[1];
+  size_t num_config = has_hvx ? 5 : 4;
+  for (size_t i = 0; i < num_config; ++i) {
+    graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
+    graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_configs[i].customConfig = &graph_custom_configs[i];
+    result[i] = &graph_configs[i];
+  }
 
-  graph_configs[2] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[2].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[2].customConfig = &graph_custom_configs[2];
-
-  graph_configs[3] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[3].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[3].customConfig = &graph_custom_configs[3];
-
-  static std::array<const QnnGraph_Config_t*, 5> result = {
-      &graph_configs[0], &graph_configs[1], &graph_configs[2],
-      &graph_configs[3], nullptr};
-
-  return absl::MakeSpan(result.data(), result.size());
+  result[num_config] = nullptr;
+  return absl::MakeSpan(result.data(), num_config + 1);
 }
 
-inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs() {
-  static std::array<QnnHtpGraph_CustomConfig_t, 3> graph_custom_configs;
+inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
+    const ::qnn::Options& options) {
+  static std::array<QnnHtpGraph_CustomConfig_t, 4> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 4> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 5> result;
   // Default use O3 for now.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
   graph_custom_configs[0].optimizationOption.type =
       QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
   // Change to 2 if you want to use O2 (default).
-  graph_custom_configs[0].optimizationOption.floatValue = 3;
+  graph_custom_configs[0].optimizationOption.floatValue =
+      static_cast<float>(options.GetOptimizationLevel());
 
   // VTCM
   graph_custom_configs[1] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[1].option = QNN_HTP_GRAPH_CONFIG_OPTION_VTCM_SIZE;
-  graph_custom_configs[1].vtcmSizeInMB = QNN_HTP_GRAPH_CONFIG_OPTION_MAX;
+  // The default value is 0 which means the MAX value
+  graph_custom_configs[1].vtcmSizeInMB = options.GetVtcmSize();
   // FoldRelu Off
   graph_custom_configs[2] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[2].option =
       QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
   graph_custom_configs[2].foldReluActivationIntoConvOff = true;
 
-  static std::array<QnnGraph_Config_t, 3> graph_configs;
-  graph_configs[0] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[0].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[0].customConfig = &graph_custom_configs[0];
+  // Hvx Thread
+  bool has_hvx = options.GetNumHvxThreads() != 0;
+  if (has_hvx) {
+    graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[3].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
+    graph_custom_configs[3].numHvxThreads = options.GetNumHvxThreads();
+  }
 
-  graph_configs[1] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[1].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[1].customConfig = &graph_custom_configs[1];
+  size_t num_config = has_hvx ? 4 : 3;
+  for (size_t i = 0; i < num_config; ++i) {
+    graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
+    graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_configs[i].customConfig = &graph_custom_configs[i];
+    result[i] = &graph_configs[i];
+  }
 
-  graph_configs[2] = QNN_GRAPH_CONFIG_INIT;
-  graph_configs[2].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_configs[2].customConfig = &graph_custom_configs[2];
-
-  static std::array<const QnnGraph_Config_t*, 4> result = {
-      &graph_configs[0], &graph_configs[1], &graph_configs[2], nullptr};
-
-  return absl::MakeSpan(result.data(), result.size());
+  result[num_config] = nullptr;
+  return absl::MakeSpan(result.data(), num_config + 1);
 }
 
-absl::Span<const QnnGraph_Config_t*> GraphMapper::PickGraphConfigHeuristic() {
+absl::Span<const QnnGraph_Config_t*> GraphMapper::PickGraphConfigHeuristic(
+    const ::qnn::Options& options) {
   if (qnn_.IsLegacySocModel()) {
-    return GetLegacyGraphConfigs();
+    return GetLegacyGraphConfigs(options);
   } else {
-    return GetDefaultGraphConfigs();
+    return GetDefaultGraphConfigs(options);
   }
 }
 
@@ -138,10 +149,11 @@ LiteRtStatus GraphMapper::IsLiteRtSubgraphSupported() {
   return kLiteRtStatusOk;
 }
 
-LiteRtStatus GraphMapper::InitQnnGraph(absl::string_view qnn_graph_name) {
-  LITERT_RETURN_STATUS_IF_QNN_NOT_OK(
-      qnn_.Api()->graphCreate(context_handle_, qnn_graph_name.data(),
-                              PickGraphConfigHeuristic().data(), &QnnGraph()));
+LiteRtStatus GraphMapper::InitQnnGraph(absl::string_view qnn_graph_name,
+                                       const ::qnn::Options& options) {
+  LITERT_RETURN_STATUS_IF_QNN_NOT_OK(qnn_.Api()->graphCreate(
+      context_handle_, qnn_graph_name.data(),
+      PickGraphConfigHeuristic(options).data(), &QnnGraph()));
   return kLiteRtStatusOk;
 }
 

--- a/litert/vendors/qualcomm/compiler/graph_mapper.h
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.h
@@ -52,7 +52,8 @@ class GraphMapper {
 
   // Initialize QNN Graph with given name. Call this after parsing
   // LiteRtSubgraph.
-  LiteRtStatus InitQnnGraph(absl::string_view qnn_graph_name);
+  LiteRtStatus InitQnnGraph(absl::string_view qnn_graph_name,
+                            const ::qnn::Options& options);
 
   // Finalize QNN Graph. Call this after all ops have been mapped.
   LiteRtStatus Finalize();
@@ -62,7 +63,8 @@ class GraphMapper {
   }
 
   // Pick graph config based on subgraph.
-  absl::Span<const QnnGraph_Config_t*> PickGraphConfigHeuristic();
+  absl::Span<const QnnGraph_Config_t*> PickGraphConfigHeuristic(
+      const ::qnn::Options& options);
 
   inline bool IsTensorOutput(LiteRtTensor litert_tensor) {
     return graph_outpus_.contains(litert_tensor);

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1027,7 +1027,7 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
                       const ::qnn::Options& options) {
   GraphMapper graph_mapper(subgraph, qnn, context_handle);
   LITERT_RETURN_IF_ERROR(graph_mapper.IsLiteRtSubgraphSupported());
-  LITERT_RETURN_IF_ERROR(graph_mapper.InitQnnGraph(qnn_graph_name));
+  LITERT_RETURN_IF_ERROR(graph_mapper.InitQnnGraph(qnn_graph_name, options));
 
   //
   // Legalize subgraph inputs and update tensors in scope

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -41,6 +41,16 @@ void Options::SetEnableWeightSharing(const bool enable_weight_sharing) {
 
 bool Options::GetEnableWeightSharing() const { return enable_weight_sharing_; }
 
+void Options::SetUseConvHMX(bool use_conv_hmx) { use_conv_hmx_ = use_conv_hmx; }
+
+bool Options::GetUseConvHMX() const { return use_conv_hmx_; }
+
+void Options::SetUseFoldReLU(bool use_fold_relu) {
+  use_fold_relu_ = use_fold_relu;
+}
+
+bool Options::GetUseFoldReLU() const { return use_fold_relu_; }
+
 void Options::SetHtpPerformanceMode(
     const HtpPerformanceMode htp_performance_mode) {
   htp_performance_mode_ = htp_performance_mode;
@@ -91,6 +101,8 @@ Profiling: %d\n\
 UseHtpPreference: %v\n\
 UseQint16AsQuint16: %v\n\
 EnableWeightSharing: %v\n\
+UseConvHMX: %v\n\
+UseFoldReLU: %v\n\
 HtpPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
 IrJsonDir: %s\n\
@@ -102,9 +114,9 @@ OptimizationLevel: %d\n";  // NOLINT
 
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
                          use_htp_preference_, use_qint16_as_quint16_,
-                         enable_weight_sharing_, htp_performance_mode_,
-                         dump_tensor_ids, ir_json_dir_, vtcm_size_,
-                         num_hvx_threads_, optimization_level_);
+                         enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
+                         htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
+                         vtcm_size_, num_hvx_threads_, optimization_level_);
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -64,6 +64,24 @@ void Options::SetIrJsonDir(absl::string_view ir_json_dir) {
   ir_json_dir_ = ir_json_dir;
 }
 
+std::uint32_t Options::GetVtcmSize() const { return vtcm_size_; }
+
+void Options::SetVtcmSize(std::uint32_t vtcm_size) { vtcm_size_ = vtcm_size; }
+
+std::uint32_t Options::GetNumHvxThreads() const { return num_hvx_threads_; }
+
+void Options::SetNumHvxThreads(std::uint32_t num_hvx_threads) {
+  num_hvx_threads_ = num_hvx_threads;
+}
+
+OptimizationLevel Options::GetOptimizationLevel() const {
+  return optimization_level_;
+}
+
+void Options::SetOptimizationLevel(OptimizationLevel optimization_level) {
+  optimization_level_ = optimization_level;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -75,14 +93,18 @@ UseQint16AsQuint16: %v\n\
 EnableWeightSharing: %v\n\
 HtpPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
-IrJsonDir: %s\n";  // NOLINT
+IrJsonDir: %s\n\
+VtcmSize: %d\n\
+HvxThread: %d\n\
+OptimizationLevel: %d\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
                          use_htp_preference_, use_qint16_as_quint16_,
                          enable_weight_sharing_, htp_performance_mode_,
-                         dump_tensor_ids, ir_json_dir_);
+                         dump_tensor_ids, ir_json_dir_, vtcm_size_,
+                         num_hvx_threads_, optimization_level_);
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -37,6 +37,12 @@ enum class HtpPerformanceMode {
   kExtremePowerSaver = 9,
 };
 
+enum class OptimizationLevel {
+  kHtpOptimizeForInference = 0,
+  kHtpOptimizeForPrepare = 1,
+  kHtpOptimizeForInferenceO3 = 2,
+};
+
 class Options {
  public:
   Options() = default;
@@ -66,6 +72,15 @@ class Options {
   absl::string_view GetIrJsonDir() const;
   void SetIrJsonDir(absl::string_view ir_json_dir);
 
+  std::uint32_t GetVtcmSize() const;
+  void SetVtcmSize(std::uint32_t vtcm_size);
+
+  std::uint32_t GetNumHvxThreads() const;
+  void SetNumHvxThreads(std::uint32_t num_hvx_threads);
+
+  void SetOptimizationLevel(OptimizationLevel optimization_level);
+  OptimizationLevel GetOptimizationLevel() const;
+
   std::string Dump() const;
 
  private:
@@ -77,6 +92,10 @@ class Options {
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;
   std::string ir_json_dir_;
+  std::uint32_t vtcm_size_;
+  std::uint32_t num_hvx_threads_;
+  OptimizationLevel optimization_level_ =
+      OptimizationLevel::kHtpOptimizeForInferenceO3;
 };
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -62,6 +62,12 @@ class Options {
   void SetEnableWeightSharing(const bool enable_weight_sharing);
   bool GetEnableWeightSharing() const;
 
+  void SetUseConvHMX(bool use_conv_hmx);
+  bool GetUseConvHMX() const;
+
+  void SetUseFoldReLU(bool use_fold_relu);
+  bool GetUseFoldReLU() const;
+
   void SetHtpPerformanceMode(const HtpPerformanceMode htp_performance_mode);
   HtpPerformanceMode GetHtpPerformanceMode() const;
 
@@ -89,6 +95,8 @@ class Options {
   bool use_htp_preference_ = false;
   bool use_qint16_as_quint16_ = false;
   bool enable_weight_sharing_ = false;
+  bool use_conv_hmx_ = false;
+  bool use_fold_relu_ = false;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;
   std::string ir_json_dir_;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -119,6 +119,36 @@ TEST(QnnOptionTest, SetIrJsonDir) {
   EXPECT_TRUE(options.GetIrJsonDir().empty());
 }
 
+TEST(QnnOptionTest, SetVtcmSize) {
+  Options options;
+  options.SetVtcmSize(4);
+  EXPECT_NE(options.GetVtcmSize(), 0);
+  EXPECT_EQ(options.GetVtcmSize(), 4);
+  options.SetVtcmSize(0);
+  EXPECT_EQ(options.GetVtcmSize(), 0);
+}
+
+TEST(QnnOptionTest, SetHvxThread) {
+  Options options;
+  options.SetNumHvxThreads(4);
+  EXPECT_NE(options.GetNumHvxThreads(), 0);
+  EXPECT_EQ(options.GetNumHvxThreads(), 4);
+  options.SetNumHvxThreads(0);
+  EXPECT_EQ(options.GetNumHvxThreads(), 0);
+}
+
+TEST(QnnOptionTest, SetOptimizationLevel) {
+  Options options;
+  options.SetOptimizationLevel(OptimizationLevel::kHtpOptimizeForPrepare);
+  EXPECT_NE(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForInferenceO3);
+  EXPECT_EQ(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForPrepare);
+  options.SetOptimizationLevel(OptimizationLevel::kHtpOptimizeForInferenceO3);
+  EXPECT_EQ(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForInferenceO3);
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -128,6 +158,10 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());
+  EXPECT_EQ(options.GetVtcmSize(), 0);
+  EXPECT_EQ(options.GetNumHvxThreads(), 0);
+  EXPECT_EQ(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForInferenceO3);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -110,6 +110,22 @@ TEST(QnnOptionTest, EnableWeightSharing) {
   EXPECT_EQ(options.GetEnableWeightSharing(), false);
 }
 
+TEST(QnnOptionTest, UseConvHMX) {
+  Options options;
+  options.SetUseConvHMX(true);
+  EXPECT_EQ(options.GetUseConvHMX(), true);
+  options.SetUseConvHMX(false);
+  EXPECT_EQ(options.GetUseConvHMX(), false);
+}
+
+TEST(QnnOptionTest, UseFoldReLU) {
+  Options options;
+  options.SetUseFoldReLU(true);
+  EXPECT_EQ(options.GetUseFoldReLU(), true);
+  options.SetUseFoldReLU(false);
+  EXPECT_EQ(options.GetUseFoldReLU(), false);
+}
+
 TEST(QnnOptionTest, SetIrJsonDir) {
   Options options;
   options.SetIrJsonDir("tmp/");
@@ -156,6 +172,8 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetUseHtpPreference());
   EXPECT_FALSE(options.GetUseQint16AsQuint16());
   EXPECT_FALSE(options.GetEnableWeightSharing());
+  EXPECT_FALSE(options.GetUseConvHMX());
+  EXPECT_FALSE(options.GetUseFoldReLU());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());
   EXPECT_EQ(options.GetVtcmSize(), 0);


### PR DESCRIPTION


# TEST
======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 11 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (32 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 33 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 33 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[  FAILED  ] SupportedOpsTest/QnnPluginOpCompatibilityTest.SupportedOpsTest/92, where GetParam() = "static_w8_a16_quantized_attn_vec_einsum.tflite"

 4 FAILED TESTS