### PR TITLE
qualcomm cmake build

### DIFF
--- a/litert/CMakeLists.txt
+++ b/litert/CMakeLists.txt
@@ -63,11 +63,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Options
-option(LITERT_BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(LITERT_BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(LITERT_BUILD_TOOLS "Build LiteRT tools" ON)
 option(LITERT_BUILD_TESTS "Build LiteRT tests" OFF)
 option(LITERT_AUTO_BUILD_TFLITE "Automatically build TFLite if not found" ON)
-option(LITERT_ENABLE_GPU "Enable GPU acceleration support" ON)
+option(LITERT_ENABLE_GPU "Enable GPU acceleration support" OFF)
 option(LITERT_ENABLE_NPU "Enable NPU acceleration support" ON)
 
 set(LITERT_GENERATED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include")
@@ -94,7 +94,7 @@ include_directories(${LITERT_GENERATED_INCLUDE_DIR})
 # Find TFLite package - we depend on it being built first
 set(TFLITE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/tflite_build" CACHE PATH "Path to TFLite build directory")
 set(TFLITE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tflite" CACHE PATH "Path to TFLite source directory")
-
+add_compile_definitions(ABSL_FLAGS_STRIP_NAMES=0)
 # Check if TFLite has been built
 if(NOT EXISTS "${TFLITE_BUILD_DIR}/libtensorflow-lite.a")
     if(LITERT_AUTO_BUILD_TFLITE)
@@ -119,6 +119,7 @@ if(NOT EXISTS "${TFLITE_BUILD_DIR}/libtensorflow-lite.a")
           if(DEFINED ANDROID_PLATFORM)
             list(APPEND _tflite_extra_args -DANDROID_PLATFORM=${ANDROID_PLATFORM})
           endif()
+          add_compile_definitions(ABSL_FLAGS_STRIP_NAMES=0)
           list(APPEND _tflite_extra_args -DCMAKE_SYSTEM_NAME=Android)
           list(APPEND _tflite_extra_args -DTFLITE_ENABLE_GPU=ON)
 

--- a/litert/CMakeLists.txt
+++ b/litert/CMakeLists.txt
@@ -63,11 +63,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Options
-option(LITERT_BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(LITERT_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(LITERT_BUILD_TOOLS "Build LiteRT tools" ON)
 option(LITERT_BUILD_TESTS "Build LiteRT tests" OFF)
 option(LITERT_AUTO_BUILD_TFLITE "Automatically build TFLite if not found" ON)
-option(LITERT_ENABLE_GPU "Enable GPU acceleration support" OFF)
+option(LITERT_ENABLE_GPU "Enable GPU acceleration support" ON)
 option(LITERT_ENABLE_NPU "Enable NPU acceleration support" ON)
 
 set(LITERT_GENERATED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include")
@@ -119,7 +119,6 @@ if(NOT EXISTS "${TFLITE_BUILD_DIR}/libtensorflow-lite.a")
           if(DEFINED ANDROID_PLATFORM)
             list(APPEND _tflite_extra_args -DANDROID_PLATFORM=${ANDROID_PLATFORM})
           endif()
-          add_compile_definitions(ABSL_FLAGS_STRIP_NAMES=0)
           list(APPEND _tflite_extra_args -DCMAKE_SYSTEM_NAME=Android)
           list(APPEND _tflite_extra_args -DTFLITE_ENABLE_GPU=ON)
 

--- a/litert/tools/CMakeLists.txt
+++ b/litert/tools/CMakeLists.txt
@@ -136,7 +136,6 @@ target_link_libraries(run_model
         litert_runtime
         tensorflow-lite
         litert_tool_flags_google_tensor
-        litert_tool_flags_intel_openvino
         litert_tool_flags_mediatek
         litert_tool_flags_qualcomm
         absl::flags
@@ -150,30 +149,30 @@ target_link_libraries(run_model
 )
 
 # analyze_model
-add_executable(analyze_model
-    analyze_model_main.cc
-)
-
-target_include_directories(analyze_model
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/..
-        ${CMAKE_CURRENT_SOURCE_DIR}/../..
-        ${TENSORFLOW_SOURCE_DIR}
-)
-
-target_link_libraries(analyze_model
-    PRIVATE
-        litert_dump
-        litert_tool_display
-        litert_core
-        litert_core_model
-        tensorflow-lite
-        absl::flags
-        absl::flags_parse
-        absl::log
-        absl::status
-        absl::statusor
-)
+# add_executable(analyze_model
+#     analyze_model_main.cc
+# )
+# 
+# target_include_directories(analyze_model
+#     PRIVATE
+#         ${CMAKE_CURRENT_SOURCE_DIR}/..
+#         ${CMAKE_CURRENT_SOURCE_DIR}/../..
+#         ${TENSORFLOW_SOURCE_DIR}
+# )
+# 
+# target_link_libraries(analyze_model
+#     PRIVATE
+#         litert_dump
+#         litert_tool_display
+#         litert_core
+#         litert_core_model
+#         tensorflow-lite
+#         absl::flags
+#         absl::flags_parse
+#         absl::log
+#         absl::status
+#         absl::statusor
+# )
 
 # apply_plugin
 add_executable(apply_plugin_main
@@ -187,6 +186,8 @@ target_include_directories(apply_plugin_main
         ${TENSORFLOW_SOURCE_DIR}
 )
 
+target_link_directories(apply_plugin_main PRIVATE ${CMAKE_BINARY_DIR}/vendors)
+
 target_link_libraries(apply_plugin_main
     PRIVATE
         litert_apply_plugin
@@ -194,10 +195,8 @@ target_link_libraries(apply_plugin_main
         litert_tool_flags_apply_plugin
         litert_tool_flags_common
         litert_tool_flags_google_tensor
-        litert_tool_flags_intel_openvino
         litert_tool_flags_mediatek
         litert_tool_flags_qualcomm
-
         litert_tool_display
         litert_core
         litert_core_model
@@ -214,7 +213,7 @@ target_link_libraries(apply_plugin_main
 # Platform-specific configurations for all executables
 if(LITERT_PLATFORM_ANDROID)
     target_link_libraries(run_model PRIVATE ${LOG_LIB})
-    target_link_libraries(analyze_model PRIVATE ${LOG_LIB})
+    # target_link_libraries(analyze_model PRIVATE ${LOG_LIB})
     target_link_libraries(apply_plugin_main PRIVATE ${LOG_LIB})
     # Statically link TFLite GPU/GL core objects for tool executables on Android.
     if(TARGET litert_tflite_gpu_gl_core)
@@ -224,6 +223,6 @@ if(LITERT_PLATFORM_ANDROID)
 endif()
 
 # Install targets
-install(TARGETS run_model analyze_model apply_plugin_main
+install(TARGETS run_model apply_plugin_main
     RUNTIME DESTINATION bin
 )

--- a/litert/tools/CMakeLists.txt
+++ b/litert/tools/CMakeLists.txt
@@ -136,6 +136,7 @@ target_link_libraries(run_model
         litert_runtime
         tensorflow-lite
         litert_tool_flags_google_tensor
+        litert_tool_flags_intel_openvino
         litert_tool_flags_mediatek
         litert_tool_flags_qualcomm
         absl::flags
@@ -149,30 +150,30 @@ target_link_libraries(run_model
 )
 
 # analyze_model
-# add_executable(analyze_model
-#     analyze_model_main.cc
-# )
-# 
-# target_include_directories(analyze_model
-#     PRIVATE
-#         ${CMAKE_CURRENT_SOURCE_DIR}/..
-#         ${CMAKE_CURRENT_SOURCE_DIR}/../..
-#         ${TENSORFLOW_SOURCE_DIR}
-# )
-# 
-# target_link_libraries(analyze_model
-#     PRIVATE
-#         litert_dump
-#         litert_tool_display
-#         litert_core
-#         litert_core_model
-#         tensorflow-lite
-#         absl::flags
-#         absl::flags_parse
-#         absl::log
-#         absl::status
-#         absl::statusor
-# )
+add_executable(analyze_model
+    analyze_model_main.cc
+)
+
+target_include_directories(analyze_model
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+        ${TENSORFLOW_SOURCE_DIR}
+)
+
+target_link_libraries(analyze_model
+    PRIVATE
+        litert_dump
+        litert_tool_display
+        litert_core
+        litert_core_model
+        tensorflow-lite
+        absl::flags
+        absl::flags_parse
+        absl::log
+        absl::status
+        absl::statusor
+)
 
 # apply_plugin
 add_executable(apply_plugin_main
@@ -186,8 +187,6 @@ target_include_directories(apply_plugin_main
         ${TENSORFLOW_SOURCE_DIR}
 )
 
-target_link_directories(apply_plugin_main PRIVATE ${CMAKE_BINARY_DIR}/vendors)
-
 target_link_libraries(apply_plugin_main
     PRIVATE
         litert_apply_plugin
@@ -195,6 +194,7 @@ target_link_libraries(apply_plugin_main
         litert_tool_flags_apply_plugin
         litert_tool_flags_common
         litert_tool_flags_google_tensor
+        litert_tool_flags_intel_openvino
         litert_tool_flags_mediatek
         litert_tool_flags_qualcomm
         litert_tool_display
@@ -213,7 +213,7 @@ target_link_libraries(apply_plugin_main
 # Platform-specific configurations for all executables
 if(LITERT_PLATFORM_ANDROID)
     target_link_libraries(run_model PRIVATE ${LOG_LIB})
-    # target_link_libraries(analyze_model PRIVATE ${LOG_LIB})
+    target_link_libraries(analyze_model PRIVATE ${LOG_LIB})
     target_link_libraries(apply_plugin_main PRIVATE ${LOG_LIB})
     # Statically link TFLite GPU/GL core objects for tool executables on Android.
     if(TARGET litert_tflite_gpu_gl_core)
@@ -223,6 +223,6 @@ if(LITERT_PLATFORM_ANDROID)
 endif()
 
 # Install targets
-install(TARGETS run_model apply_plugin_main
+install(TARGETS run_model analyze_model apply_plugin_main
     RUNTIME DESTINATION bin
 )

--- a/litert/vendors/CMakeLists.txt
+++ b/litert/vendors/CMakeLists.txt
@@ -16,9 +16,11 @@ cmake_minimum_required(VERSION 3.20)
 include(CheckIncludeFileCXX)
 include(FetchContent)
 
-option(LITERT_ENABLE_MEDIATEK "Enable MediaTek dispatch build" OFF)
+option(LITERT_ENABLE_MEDIATEK "Enable MediaTek vendor build" OFF)
+option(LITERT_OFFLINE_BUILD "Use local dependencies instead of fetching from remote" OFF)
 set(NEUROPILOT_HEADERS_DIR "" CACHE PATH "Path to pre-downloaded NeuroPilot headers (root containing neuron/api)")
 set(QAIRT_HEADERS_DIR "" CACHE PATH "Path to pre-downloaded QAIRT/QNN headers (root containing Qnn*.h)")
+set(LITERT_TOOLS_DEP $ENV{LITERT_TOOLS_DEP})
 
 if(LITERT_ENABLE_MEDIATEK)
   if(NOT NEUROPILOT_HEADERS_DIR)
@@ -124,66 +126,69 @@ function(_litert_add_dispatch_so VENDOR DIR OUTPUT_BASENAME)
     "${SRC_DIR}/device_context.cc"
     "${SRC_DIR}/invocation_context.cc"
   )
-
-  if(VENDOR STREQUAL "MediaTek")
-    set(FLATC_EXECUTABLE "")
-    if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-      if(TFLITE_HOST_TOOLS_DIR AND EXISTS "${TFLITE_HOST_TOOLS_DIR}/flatc")
-        set(FLATC_EXECUTABLE "${TFLITE_HOST_TOOLS_DIR}/flatc")
-      elseif(TFLITE_BUILD_DIR AND EXISTS "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
-        set(FLATC_EXECUTABLE "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
+  if(LITERT_ENABLE_MEDIATEK)
+    if(VENDOR STREQUAL "MediaTek")
+      set(FLATC_EXECUTABLE "")
+      if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+        if(TFLITE_HOST_TOOLS_DIR AND EXISTS "${TFLITE_HOST_TOOLS_DIR}/flatc")
+          set(FLATC_EXECUTABLE "${TFLITE_HOST_TOOLS_DIR}/flatc")
+        elseif(TFLITE_BUILD_DIR AND EXISTS "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
+          set(FLATC_EXECUTABLE "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
+        endif()
       endif()
-    endif()
-    if(NOT FLATC_EXECUTABLE)
-      find_program(FLATC_EXECUTABLE NAMES flatc)
-    endif()
-    if(NOT FLATC_EXECUTABLE)
-      message(STATUS "flatc not found in PATH; fetching FlatBuffers to build flatc")
-      FetchContent_Declare(flatbuffers
-        GIT_REPOSITORY https://github.com/google/flatbuffers.git
-        GIT_TAG v25.9.23
-      )
-      set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-      FetchContent_MakeAvailable(flatbuffers)
-      if(NOT TARGET flatc)
-        message(FATAL_ERROR "FlatBuffers 'flatc' target not available after fetch")
+      if(NOT FLATC_EXECUTABLE)
+        find_program(FLATC_EXECUTABLE NAMES flatc)
       endif()
-      set(FLATC_EXECUTABLE $<TARGET_FILE:flatc>)
+      if(NOT FLATC_EXECUTABLE)
+        message(STATUS "flatc not found in PATH; fetching FlatBuffers to build flatc")
+        FetchContent_Declare(flatbuffers
+          GIT_REPOSITORY https://github.com/google/flatbuffers.git
+          GIT_TAG v25.9.23
+        )
+        set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(flatbuffers)
+        if(NOT TARGET flatc)
+          message(FATAL_ERROR "FlatBuffers 'flatc' target not available after fetch")
+        endif()
+        set(FLATC_EXECUTABLE $<TARGET_FILE:flatc>)
+      endif()
+      set(_mtk_gen_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/include/litert/vendors/mediatek/schema")
+      file(MAKE_DIRECTORY "${_mtk_gen_dir}")
+      set(_mtk_schema "${CMAKE_CURRENT_SOURCE_DIR}/mediatek/schema/neuron_schema.fbs")
+      set(_mtk_gen_hdr "${_mtk_gen_dir}/neuron_schema_generated.h")
+      add_custom_command(
+        OUTPUT "${_mtk_gen_hdr}"
+        COMMAND ${FLATC_EXECUTABLE} --cpp -o "${_mtk_gen_dir}" "${_mtk_schema}"
+        DEPENDS "${_mtk_schema}"
+        COMMENT "Generating MediaTek neuron_schema_generated.h with flatc"
+        VERBATIM)
+      add_custom_target(mediatek_schema_gen DEPENDS "${_mtk_gen_hdr}")
+      list(APPEND DISPATCH_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/mediatek/neuron_adapter_api.cc")
     endif()
-    set(_mtk_gen_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/include/litert/vendors/mediatek/schema")
-    file(MAKE_DIRECTORY "${_mtk_gen_dir}")
-    set(_mtk_schema "${CMAKE_CURRENT_SOURCE_DIR}/mediatek/schema/neuron_schema.fbs")
-    set(_mtk_gen_hdr "${_mtk_gen_dir}/neuron_schema_generated.h")
-    add_custom_command(
-      OUTPUT "${_mtk_gen_hdr}"
-      COMMAND ${FLATC_EXECUTABLE} --cpp -o "${_mtk_gen_dir}" "${_mtk_schema}"
-      DEPENDS "${_mtk_schema}"
-      COMMENT "Generating MediaTek neuron_schema_generated.h with flatc"
-      VERBATIM)
-    add_custom_target(mediatek_schema_gen DEPENDS "${_mtk_gen_hdr}")
-    list(APPEND DISPATCH_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/mediatek/neuron_adapter_api.cc")
   endif()
 
-  if(VENDOR STREQUAL "Qualcomm")
-    list(APPEND DISPATCH_SRCS
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/qnn_manager.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/context_binary_info.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/common.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/utils/miscs.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/schema/soc_table.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/qnn_backend.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/htp_backend.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/htp_perf_control.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/ir_backend.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/quantize_params_wrapper.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/tensor_wrapper.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/param_wrapper.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/op_wrapper.cc"
-    )
-    if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-      list(APPEND DISPATCH_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/utils/log_android.cc")
-    else()
-      list(APPEND DISPATCH_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/utils/log_default.cc")
+  if(LITERT_ENABLE_QUALCOMM)
+    if(VENDOR STREQUAL "Qualcomm")
+      list(APPEND DISPATCH_SRCS
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/qnn_manager.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/context_binary_info.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/common.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/utils/miscs.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/schema/soc_table.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/qnn_backend.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/htp_backend.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/htp_perf_control.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/backends/ir_backend.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/quantize_params_wrapper.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/tensor_wrapper.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/param_wrapper.cc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/wrappers/op_wrapper.cc"
+      )
+      if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+        list(APPEND DISPATCH_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/utils/log_android.cc")
+      else()
+        list(APPEND DISPATCH_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core/utils/log_default.cc")
+      endif()
     endif()
   endif()
 
@@ -264,22 +269,44 @@ if(LITERT_ENABLE_QUALCOMM)
 
   # Add the Qualcomm compiler plugin build for host
   message(STATUS "Building Qualcomm compiler plugin for host")
-     
-  FetchContent_Declare(
-    nlohmann_json
-    GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG v3.11.2
-  )
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        e2239ee6043f73722e7aa812a459f54a28552929 # release-1.11.0
-)
-  FetchContent_Declare(
+    
+  if(LITERT_OFFLINE_BUILD)
+  message(STATUS "Building in offline mode, using local dependencies")
+    FetchContent_Declare(
+      nlohmann_json
+      # GIT_REPOSITORY https://github.com/nlohmann/json.git
+      URL ${LITERT_TOOLS_DEP}/json
+      # GIT_TAG v3.11.3
+    )
+    FetchContent_Declare(
+      googletest
+      # GIT_REPOSITORY https://github.com/google/googletest.git
+      URL ${LITERT_TOOLS_DEP}/googletest
+      # GIT_TAG        e2239ee6043f73722e7aa812a459f54a28552929 # release-1.11.0
+    )
+    FetchContent_Declare(
+        googlebenchmark
+        URL ${LITERT_TOOLS_DEP}/benchmark
+        # GIT_REPOSITORY https://github.com/google/benchmark.git
+        # GIT_TAG        0d98dba29d66e93259db7daa53a9327df767a415 # v1.6.1
+    )
+  else()
+    FetchContent_Declare(
+      nlohmann_json
+      GIT_REPOSITORY https://github.com/nlohmann/json.git
+      GIT_TAG v3.11.3
+    )
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG        v1.12.x # release-1.12.x
+    )
+    FetchContent_Declare(
       googlebenchmark
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG        0d98dba29d66e93259db7daa53a9327df767a415 # v1.6.1
-  )
+    )
+  endif()
   FetchContent_MakeAvailable(nlohmann_json)
   FetchContent_MakeAvailable(googletest)
   FetchContent_MakeAvailable(googlebenchmark)

--- a/litert/vendors/CMakeLists.txt
+++ b/litert/vendors/CMakeLists.txt
@@ -16,43 +16,46 @@ cmake_minimum_required(VERSION 3.20)
 include(CheckIncludeFileCXX)
 include(FetchContent)
 
+option(LITERT_ENABLE_MEDIATEK "Enable MediaTek dispatch build" OFF)
 set(NEUROPILOT_HEADERS_DIR "" CACHE PATH "Path to pre-downloaded NeuroPilot headers (root containing neuron/api)")
 set(QAIRT_HEADERS_DIR "" CACHE PATH "Path to pre-downloaded QAIRT/QNN headers (root containing Qnn*.h)")
 
-if(NOT NEUROPILOT_HEADERS_DIR)
-  if(NOT NEUROPILOT_HEADERS_URL AND NOT NEUROPILOT_GIT_REPO)
-    set(NEUROPILOT_HEADERS_URL "https://s3.ap-southeast-1.amazonaws.com/mediatek.neuropilot.com/57c17aa0-90b4-4871-a7b6-cdcdc678b3aa.gz")
-  endif()
-  if(NEUROPILOT_HEADERS_URL OR NEUROPILOT_GIT_REPO)
-    if(NEUROPILOT_HEADERS_URL)
-      FetchContent_Declare(neuro_pilot
-        URL ${NEUROPILOT_HEADERS_URL}
-      )
-    else()
-      FetchContent_Declare(neuro_pilot
-        GIT_REPOSITORY ${NEUROPILOT_GIT_REPO}
-        GIT_TAG        ${NEUROPILOT_GIT_TAG}
-      )
+if(LITERT_ENABLE_MEDIATEK)
+  if(NOT NEUROPILOT_HEADERS_DIR)
+    if(NOT NEUROPILOT_HEADERS_URL AND NOT NEUROPILOT_GIT_REPO)
+      set(NEUROPILOT_HEADERS_URL "https://s3.ap-southeast-1.amazonaws.com/mediatek.neuropilot.com/57c17aa0-90b4-4871-a7b6-cdcdc678b3aa.gz")
     endif()
-    FetchContent_MakeAvailable(neuro_pilot)
-    set(NEUROPILOT_HEADERS_DIR ${neuro_pilot_SOURCE_DIR})
-    set(_np_candidates)
-    list(APPEND _np_candidates
-      "${NEUROPILOT_HEADERS_DIR}/${NEUROPILOT_HEADERS_SUBDIR}"
-      "${NEUROPILOT_HEADERS_DIR}/v8_latest/host/include"
-      "${NEUROPILOT_HEADERS_DIR}/v9_latest/host/include"
-      "${NEUROPILOT_HEADERS_DIR}/v7_latest/host/include"
-      "${NEUROPILOT_HEADERS_DIR}/v8_0_8/host/include"
-      "${NEUROPILOT_HEADERS_DIR}/host/include"
-      "${NEUROPILOT_HEADERS_DIR}/include"
-    )
-    foreach(_cand IN LISTS _np_candidates)
-      if(_cand AND EXISTS "${_cand}/neuron/api/NeuronAdapter.h")
-        set(NEUROPILOT_HEADERS_DIR "${_cand}")
-        break()
+    if(NEUROPILOT_HEADERS_URL OR NEUROPILOT_GIT_REPO)
+      if(NEUROPILOT_HEADERS_URL)
+        FetchContent_Declare(neuro_pilot
+          URL ${NEUROPILOT_HEADERS_URL}
+        )
+      else()
+        FetchContent_Declare(neuro_pilot
+          GIT_REPOSITORY ${NEUROPILOT_GIT_REPO}
+          GIT_TAG        ${NEUROPILOT_GIT_TAG}
+        )
       endif()
-    endforeach()
-    message(STATUS "NeuroPilot headers at: ${NEUROPILOT_HEADERS_DIR}")
+      FetchContent_MakeAvailable(neuro_pilot)
+      set(NEUROPILOT_HEADERS_DIR ${neuro_pilot_SOURCE_DIR})
+      set(_np_candidates)
+      list(APPEND _np_candidates
+        "${NEUROPILOT_HEADERS_DIR}/${NEUROPILOT_HEADERS_SUBDIR}"
+        "${NEUROPILOT_HEADERS_DIR}/v8_latest/host/include"
+        "${NEUROPILOT_HEADERS_DIR}/v9_latest/host/include"
+        "${NEUROPILOT_HEADERS_DIR}/v7_latest/host/include"
+        "${NEUROPILOT_HEADERS_DIR}/v8_0_8/host/include"
+        "${NEUROPILOT_HEADERS_DIR}/host/include"
+        "${NEUROPILOT_HEADERS_DIR}/include"
+      )
+      foreach(_cand IN LISTS _np_candidates)
+        if(_cand AND EXISTS "${_cand}/neuron/api/NeuronAdapter.h")
+          set(NEUROPILOT_HEADERS_DIR "${_cand}")
+          break()
+        endif()
+      endforeach()
+      message(STATUS "NeuroPilot headers at: ${NEUROPILOT_HEADERS_DIR}")
+    endif()
   endif()
 endif()
 
@@ -224,24 +227,23 @@ function(_litert_add_dispatch_so VENDOR DIR OUTPUT_BASENAME)
   )
 
   if(UNIX AND NOT APPLE)
-        target_link_options(${TGT} PRIVATE "-Wl,-soname=libLiteRtDispatch_${OUTPUT_BASENAME}.so"
-          -Wl,--whole-archive)
-        target_link_libraries(${TGT} PRIVATE litert_runtime_c_api_static)
-        target_link_options(${TGT} PRIVATE -Wl,--no-whole-archive)
+    target_link_options(${TGT} PRIVATE "-Wl,-soname=libLiteRtDispatch_${OUTPUT_BASENAME}.so")
   endif()
 endfunction()
 
 # Google Tensor
 _litert_add_dispatch_so(GoogleTensor "google_tensor/dispatch" "GoogleTensor")
 # MediaTek
-check_include_file_cxx("neuron/api/NeuronAdapter.h" HAVE_MEDIATEK_NEURON_HDR)
-if(NEUROPILOT_HEADERS_DIR AND EXISTS "${NEUROPILOT_HEADERS_DIR}/neuron/api/NeuronAdapter.h")
-  set(HAVE_MEDIATEK_NEURON_HDR TRUE)
-endif()
-if(HAVE_MEDIATEK_NEURON_HDR)
-  _litert_add_dispatch_so(MediaTek "mediatek/dispatch" "MediaTek")
-else()
-  message(STATUS "Skipping MediaTek dispatch: neuron/api/NeuronAdapter.h not found")
+if(LITERT_ENABLE_MEDIATEK)
+  check_include_file_cxx("neuron/api/NeuronAdapter.h" HAVE_MEDIATEK_NEURON_HDR)
+  if(NEUROPILOT_HEADERS_DIR AND EXISTS "${NEUROPILOT_HEADERS_DIR}/neuron/api/NeuronAdapter.h")
+    set(HAVE_MEDIATEK_NEURON_HDR TRUE)
+  endif()
+  if(HAVE_MEDIATEK_NEURON_HDR)
+    _litert_add_dispatch_so(MediaTek "mediatek/dispatch" "MediaTek")
+  else()
+    message(STATUS "Skipping MediaTek dispatch: neuron/api/NeuronAdapter.h not found")
+  endif()
 endif()
 # Intel OpenVINO
 check_include_file_cxx("openvino/openvino.hpp" HAVE_OPENVINO_HDR)
@@ -252,11 +254,189 @@ else()
 endif()
 
 # Qualcomm
-option(LITERT_ENABLE_QUALCOMM "Enable Qualcomm dispatch build (requires QNN SDK headers/libs)" OFF)
+option(LITERT_ENABLE_QUALCOMM "Enable Qualcomm dispatch build (requires QNN SDK headers/libs)" ON)
 if(QAIRT_HEADERS_DIR AND NOT LITERT_ENABLE_QUALCOMM)
   message(STATUS "Enabling Qualcomm dispatch: QNN headers detected at ${QAIRT_HEADERS_DIR}")
   set(LITERT_ENABLE_QUALCOMM ON CACHE BOOL "" FORCE)
 endif()
 if(LITERT_ENABLE_QUALCOMM)
   _litert_add_dispatch_so(Qualcomm "qualcomm/dispatch" "Qualcomm")
+
+  # Add the Qualcomm compiler plugin build for host
+  message(STATUS "Building Qualcomm compiler plugin for host")
+     
+  FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.2
+  )
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        e2239ee6043f73722e7aa812a459f54a28552929 # release-1.11.0
+)
+  FetchContent_Declare(
+      googlebenchmark
+      GIT_REPOSITORY https://github.com/google/benchmark.git
+      GIT_TAG        0d98dba29d66e93259db7daa53a9327df767a415 # v1.6.1
+  )
+  FetchContent_MakeAvailable(nlohmann_json)
+  FetchContent_MakeAvailable(googletest)
+  FetchContent_MakeAvailable(googlebenchmark)
+  file(GLOB BUILDER_SRCS
+    "qualcomm/core/builders/*.cc"
+    "qualcomm/core/transformation/*.cc"
+    "qualcomm/core/dump/*.cc"
+  )
+  add_library(qnn_compiler_plugin SHARED
+    "qualcomm/compiler/qnn_compiler_plugin.cc"
+    "qualcomm/compiler/qnn_compose_graph.cc"
+    "qualcomm/compiler/graph_mapper.cc"
+    "qualcomm/qnn_manager.cc"
+    "qualcomm/context_binary_info.cc"
+    "qualcomm/core/common.cc"
+    "qualcomm/core/tensor_pool.cc"
+    "qualcomm/core/utils/miscs.cc"
+    "qualcomm/core/schema/soc_table.cc"
+    "qualcomm/core/backends/qnn_backend.cc"
+    "qualcomm/core/backends/htp_backend.cc"
+    "qualcomm/core/backends/htp_perf_control.cc"
+    "qualcomm/core/backends/ir_backend.cc"
+    "qualcomm/core/wrappers/quantize_params_wrapper.cc"
+    "qualcomm/core/wrappers/tensor_wrapper.cc"
+    "qualcomm/core/wrappers/param_wrapper.cc"
+    "qualcomm/core/wrappers/op_wrapper.cc"
+    "qualcomm/core/utils/log_default.cc"
+    ${BUILDER_SRCS}
+  )
+  target_include_directories(qnn_compiler_plugin
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/..>
+      $<BUILD_INTERFACE:${TENSORFLOW_SOURCE_DIR}>
+      $<BUILD_INTERFACE:${TFLITE_SOURCE_DIR}>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/qualcomm>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/qualcomm/core>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+    )
+    target_link_libraries(qnn_compiler_plugin
+      PUBLIC
+        litert_cc_api
+        litert_core
+        absl::strings
+        absl::str_format
+        litert_cc_options
+        litert_core_model
+        nlohmann_json::nlohmann_json
+        GTest::gtest
+      PRIVATE
+        tensorflow-lite
+        absl::log
+        absl::check
+    )
+    set_target_properties(qnn_compiler_plugin PROPERTIES
+    OUTPUT_NAME "LiteRtCompilerPlugin_Qualcomm"
+    POSITION_INDEPENDENT_CODE ON
+  )
+  if(UNIX AND NOT APPLE)
+    target_link_options(qnn_compiler_plugin PRIVATE "-Wl,-soname=libLiteRtCompilerPlugin_Qualcomm.so")
+  endif()
+
+  if(LITERT_BUILD_TESTS)
+    add_library(litert_test_common STATIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/../test/common.cc"
+    )
+    target_include_directories(litert_test_common PUBLIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/../test"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../"
+      "${TENSORFLOW_SOURCE_DIR}"
+      "${TENSORFLOW_SOURCE_DIR}/third_party/xla/third_party/tsl"
+    )
+    target_link_libraries(litert_test_common PUBLIC
+      GTest::gmock
+      tensorflow-lite
+      absl::string_view
+      flatbuffers::flatbuffers
+    )
+
+    add_executable(qnn_compiler_plugin_test "qualcomm/compiler/qnn_compiler_plugin_test.cc")
+    target_link_libraries(qnn_compiler_plugin_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(qnn_manager_test "qualcomm/qnn_manager_test.cc" "qualcomm/tools/dump.cc")
+    target_link_libraries(qnn_manager_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(common_test "qualcomm/core/common_test.cc")
+    target_link_libraries(common_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(tensor_pool_test "qualcomm/core/tensor_pool_test.cc")
+    target_link_libraries(tensor_pool_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(op_wrapper_test "qualcomm/core/wrappers/tests/op_wrapper_test.cc")
+    target_link_libraries(op_wrapper_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(tensor_wrapper_test "qualcomm/core/wrappers/tests/tensor_wrapper_test.cc")
+    target_link_libraries(tensor_wrapper_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(param_wrapper_test "qualcomm/core/wrappers/tests/param_wrapper_test.cc")
+    target_link_libraries(param_wrapper_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(quantize_params_wrapper_test "qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc")
+    target_link_libraries(quantize_params_wrapper_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(utils_test "qualcomm/core/utils/utils_test.cc")
+    target_link_libraries(utils_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+
+    add_executable(qnn_backend_test "qualcomm/core/backends/qnn_backend_test.cc")
+    target_link_libraries(qnn_backend_test
+      PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+    )
+  endif()
 endif()


### PR DESCRIPTION
Enable all Qualcomm CMake components. Currently, using a single CMake file for testing, but I need to separate them to follow a design pattern.

```
cmake --preset android-arm64 -DQAIRT_HEADERS_DIR=/local/mnt/workspace/chengwl/dev/latest/LiteRT/third_party/qairt/latest/include/QNN -DLITERT_BUILD_TESTS=ON


cmake --build cmake_build_android_arm64 -j


cmake --preset android-arm64 -DTFLITE_HOST_TOOLS_DIR="$(cd ../host_flatc_build/_deps/flatbuffers-build && pwd)";
```
