### PR TITLE
Qualcomm AI Engine Direct - FastVLM Decode MHA-SHA Optimization.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/concatenation_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/concatenation_op_builder.cc
@@ -33,4 +33,19 @@ std::vector<OpWrapper> BuildConcatenationOp(
   return res;
 }
 
+OpWrapper CreateConcatenationOp(
+    const std::vector<ConstTensorWrapperRef>& inputs,
+    const TensorWrapper& output, std::uint32_t axis) {
+  auto name = GetUniqueOpName(QNN_OP_CONCAT);
+  OpWrapper op;
+  op.SetName(std::move(name));
+  op.SetType(QNN_OP_CONCAT, QnnOpCode::kConcat);
+  for (const auto& input : inputs) {
+    op.AddInputTensor(input);
+  }
+  op.AddOutputTensor(output);
+  op.AddScalarParam<std::uint32_t>(QNN_OP_CONCAT_PARAM_AXIS, axis);
+  return op;
+}
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h
@@ -15,6 +15,10 @@ std::vector<OpWrapper> BuildConcatenationOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::int32_t axis);
 
+OpWrapper CreateConcatenationOp(
+    const std::vector<ConstTensorWrapperRef>& inputs,
+    const TensorWrapper& output, std::uint32_t axis);
+
 }  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CONCATENATION_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/builders/reshape_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/reshape_op_builder.cc
@@ -25,4 +25,15 @@ std::vector<OpWrapper> BuildReshapeOp(
   return res;
 }
 
+OpWrapper CreateReshapeOp(const TensorWrapper& input_0,
+                          const TensorWrapper& output_0) {
+  auto name = GetUniqueOpName(QNN_OP_RESHAPE);
+  OpWrapper op;
+  op.SetName(std::move(name));
+  op.SetType(QNN_OP_RESHAPE, QnnOpCode::kReshape);
+  op.AddInputTensor(input_0);
+  op.AddOutputTensor(output_0);
+  return op;
+}
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/reshape_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/reshape_op_builder.h
@@ -15,6 +15,9 @@ std::vector<OpWrapper> BuildReshapeOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);
 
+OpWrapper CreateReshapeOp(const TensorWrapper& input_0,
+                          const TensorWrapper& output_0);
+
 }  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_RESHAPE_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -86,8 +86,8 @@ void Transform(std::function<bool(OpWrapper&)> validate_op_config,
 }  // namespace
 
 // TODO (jiunkaiy): Add more G2G transformation.
-void GraphToGraphTransform(G2GConfig g2g_option,
-                           std::vector<OpWrapper>& ops, TensorPool& tensor_pool,
+void GraphToGraphTransform(G2GConfig g2g_option, std::vector<OpWrapper>& ops,
+                           TensorPool& tensor_pool,
                            std::function<bool(OpWrapper&)> validate_op_config) {
   if (g2g_option == G2GConfig::kOff) {
     return;
@@ -253,23 +253,6 @@ void GraphToGraphTransform(G2GConfig g2g_option,
   Transform(validate_op_config, ops, tensor_pool, fast_vlm_mha_prefill,
             OptimizeMHAFastVlmPrefill);
 
-  // Attention Optimization
-  const std::vector<QnnOpCode> attn = {
-      QnnOpCode::kElementWiseBinary,
-      QnnOpCode::kElementWiseBinary,
-      QnnOpCode::kTranspose,
-      QnnOpCode::kTranspose,
-      QnnOpCode::kMatMul,
-      QnnOpCode::kReshape,
-      QnnOpCode::kElementWiseBinary,
-      QnnOpCode::kElementWiseSelect,
-      QnnOpCode::kSoftmax,
-      QnnOpCode::kTranspose,
-      QnnOpCode::kMatMul,
-      QnnOpCode::kTranspose,
-  };
-  Transform(validate_op_config, ops, tensor_pool, attn, OptimizeMHAAttn);
-
   // Kv-swapped Fast Vlm Optimization
   const std::vector<QnnOpCode> kv_swapped_fastvlm_prefill = {
       QnnOpCode::kElementWiseBinary,
@@ -291,5 +274,42 @@ void GraphToGraphTransform(G2GConfig g2g_option,
       QnnOpCode::kReshape};
   Transform(validate_op_config, ops, tensor_pool, kv_swapped_fastvlm_prefill,
             OptimizeKvSwappedFastVlmPrefill);
+
+  // This optimization can be applied on FastVlm decode and Kanana decode.
+  const std::vector<QnnOpCode> fast_vlm_mha_decode = {
+      QnnOpCode::kElementWiseBinary,  // mul
+      QnnOpCode::kReshape,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kConcat,
+      QnnOpCode::kReshape,
+      QnnOpCode::kElementWiseBinary,  // add
+      QnnOpCode::kReshape,
+      QnnOpCode::kSoftmax,
+      QnnOpCode::kStridedSlice,
+      QnnOpCode::kStridedSlice,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kElementWiseBinary,  // add
+      QnnOpCode::kReshape};
+  Transform(validate_op_config, ops, tensor_pool, fast_vlm_mha_decode,
+            OptimizeMHAFastVlmDecode);
+
+  // Attention Optimization
+  const std::vector<QnnOpCode> attn = {
+      QnnOpCode::kElementWiseBinary,
+      QnnOpCode::kElementWiseBinary,
+      QnnOpCode::kTranspose,
+      QnnOpCode::kTranspose,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kReshape,
+      QnnOpCode::kElementWiseBinary,
+      QnnOpCode::kElementWiseSelect,
+      QnnOpCode::kSoftmax,
+      QnnOpCode::kTranspose,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kTranspose,
+  };
+  Transform(validate_op_config, ops, tensor_pool, attn, OptimizeMHAAttn);
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -787,6 +787,164 @@ size_t OptimizeMHAFastVlmPrefill(
       "[G2G] Validation failed. Rolling back to the original graph.");
   return 1;
 }
+
+size_t OptimizeMHAFastVlmDecode(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  QNN_LOG_INFO("[G2G] MHA optimization (fast vlm decode)");
+
+  constexpr size_t kQScaleMulIdx = 0;
+  constexpr size_t kQScaleReshapeIdx = 1;
+  constexpr size_t kQKCacheMatmulIdx = 2;
+  constexpr size_t kQKSliceMatmulIdx = 3;
+  constexpr size_t kQKConcatIdx = 4;
+  constexpr size_t kPreMaskReshapeIdx = 5;
+  constexpr size_t kMaskAddIdx = 6;
+  constexpr size_t kPostMaskReshapeIdx = 7;
+  constexpr size_t kSoftmaxIdx = 8;
+  constexpr size_t kQKVCacheSliceIdx = 9;
+  constexpr size_t kQKVSliceSliceIdx = 10;
+  constexpr size_t kQKVCacheMatmulIdx = 11;
+  constexpr size_t kQKVSliceMatmulIdx = 12;
+  constexpr size_t kQKVAddIdx = 13;
+  constexpr size_t kQKVReshapeIdx = 14;
+  const auto& q_scale_mul = ops[start_index + kQScaleMulIdx];
+  const auto& q_scale_reshape = ops[start_index + kQScaleReshapeIdx];
+  const auto& q_kcache_matmul = ops[start_index + kQKCacheMatmulIdx];
+  const auto& q_kslice_matmul = ops[start_index + kQKSliceMatmulIdx];
+  const auto& qk_concat = ops[start_index + kQKConcatIdx];
+  const auto& pre_mask_reshape = ops[start_index + kPreMaskReshapeIdx];
+  const auto& mask_add = ops[start_index + kMaskAddIdx];
+  const auto& post_mask_reshape = ops[start_index + kPostMaskReshapeIdx];
+  const auto& softmax = ops[start_index + kSoftmaxIdx];
+  const auto& qk_vcache_slice = ops[start_index + kQKVCacheSliceIdx];
+  const auto& qk_vslice_slice = ops[start_index + kQKVSliceSliceIdx];
+  const auto& qk_vcache_matmul = ops[start_index + kQKVCacheMatmulIdx];
+  const auto& qk_vslice_matmul = ops[start_index + kQKVSliceMatmulIdx];
+  const auto& qkv_add = ops[start_index + kQKVAddIdx];
+  const auto& qkv_reshape = ops[start_index + kQKVReshapeIdx];
+
+  const auto is_connected =
+      [](const OpWrapper& output, size_t output_tensor_index,
+         const OpWrapper& input, size_t input_tensor_index) -> bool {
+    return output.GetOutputTensor(output_tensor_index) ==
+           input.GetInputTensor(input_tensor_index);
+  };
+  if (!(is_connected(q_scale_mul, 0, q_scale_reshape, 0) &&
+        is_connected(q_scale_reshape, 0, q_kcache_matmul, 0) &&
+        is_connected(q_scale_reshape, 0, q_kslice_matmul, 0) &&
+        is_connected(q_kcache_matmul, 0, qk_concat, 0) &&
+        is_connected(q_kslice_matmul, 0, qk_concat, 1) &&
+        is_connected(qk_concat, 0, pre_mask_reshape, 0) &&
+        is_connected(pre_mask_reshape, 0, mask_add, 0) &&
+        is_connected(mask_add, 0, post_mask_reshape, 0) &&
+        is_connected(post_mask_reshape, 0, softmax, 0) &&
+        is_connected(softmax, 0, qk_vcache_slice, 0) &&
+        is_connected(softmax, 0, qk_vslice_slice, 0) &&
+        is_connected(qk_vcache_slice, 0, qk_vcache_matmul, 0) &&
+        is_connected(qk_vslice_slice, 0, qk_vslice_matmul, 0) &&
+        is_connected(qk_vcache_matmul, 0, qkv_add, 0) &&
+        is_connected(qk_vslice_matmul, 0, qkv_add, 1) &&
+        is_connected(qkv_add, 0, qkv_reshape, 0))) {
+    QNN_LOG_WARNING(
+        "[G2G] Failed to check connectivity when doing MHA-SHA transformation "
+        "for FastVLM decode.");
+    return 1;
+  }
+
+  constexpr size_t kSupportedRank = 4;
+  constexpr size_t kUnpackAxis = 1;
+  if (q_scale_mul.GetInputTensor(0).GetRank() != kSupportedRank ||
+      q_kcache_matmul.GetInputTensor(1).GetRank() != kSupportedRank ||
+      q_kslice_matmul.GetInputTensor(1).GetRank() != kSupportedRank ||
+      qk_vcache_matmul.GetInputTensor(1).GetRank() != kSupportedRank ||
+      qk_vslice_matmul.GetInputTensor(1).GetRank() != kSupportedRank ||
+      mask_add.GetInputTensor(1).GetRank() != kSupportedRank ||
+      mask_add.GetInputTensor(1).GetDimension(0) != 1 ||
+      mask_add.GetInputTensor(1).GetDimension(1) != 1) {
+    QNN_LOG_WARNING(
+        "[G2G] Failed to check dimensions when doing MHA-SHA transformation "
+        "for FastVLM decode.");
+    return 1;
+  }
+
+  std::vector<OpWrapper> new_ops;
+
+  auto scale_mul_unpack_outputs = UnpackTensor(
+      tensor_pool, new_ops, q_scale_mul.GetInputTensor(0), kUnpackAxis);
+
+  auto k_slice_unpack_outputs = UnpackTensor(
+      tensor_pool, new_ops, q_kslice_matmul.GetInputTensor(1), kUnpackAxis);
+
+  auto k_cache_unpack_outputs = UnpackTensor(
+      tensor_pool, new_ops, q_kcache_matmul.GetInputTensor(1), kUnpackAxis);
+
+  auto v_cache_unpack_outputs = UnpackTensor(
+      tensor_pool, new_ops, qk_vcache_matmul.GetInputTensor(1), kUnpackAxis);
+
+  auto v_slice_unpack_outputs = UnpackTensor(
+      tensor_pool, new_ops, qk_vslice_matmul.GetInputTensor(1), kUnpackAxis);
+
+  // Build SHA
+  const auto num_attn_head = scale_mul_unpack_outputs.size();
+  const auto num_kv_head = k_slice_unpack_outputs.size();
+  const auto num_attn_per_kv_head = num_attn_head / num_kv_head;
+  std::vector<ConstTensorWrapperRef> sha_outputs;
+  for (size_t i = 0; i < num_kv_head; ++i) {
+    for (size_t j = 0; j < num_attn_per_kv_head; ++j) {
+      const auto& sha_output = BuildSingleSHAByUnpackAxis1(
+          new_ops, tensor_pool, num_attn_per_kv_head,
+          scale_mul_unpack_outputs[i * num_attn_per_kv_head + j],
+          k_cache_unpack_outputs[i], k_slice_unpack_outputs[i],
+          v_cache_unpack_outputs[i], v_slice_unpack_outputs[i], q_scale_mul,
+          q_kcache_matmul, q_kslice_matmul, qk_concat, mask_add,
+          post_mask_reshape, softmax, qk_vcache_slice, qk_vslice_slice,
+          qk_vcache_matmul, qk_vslice_matmul, qkv_add);
+      sha_outputs.emplace_back(sha_output);
+    }
+  }
+
+  // Concat SHA outputs by the second-to-last dimension.
+  const auto concat_axis = sha_outputs[0].get().GetRank() - 2;
+  auto concat_sha_dims = sha_outputs[0].get().GetDimensions();
+  concat_sha_dims[concat_axis] = 0;
+  for (const auto& sha_output : sha_outputs) {
+    concat_sha_dims[concat_axis] += sha_output.get().GetDimension(concat_axis);
+  }
+  const auto& concat_sha_output = tensor_pool.CloneNativeTensorFrom(
+      qkv_reshape.GetInputTensor(0), concat_sha_dims);
+  new_ops.emplace_back(
+      CreateConcatenationOp(sha_outputs, concat_sha_output, concat_axis));
+  new_ops.emplace_back(
+      CreateReshapeOp(concat_sha_output, qkv_reshape.GetOutputTensor(0)));
+
+  // Validate new graph.
+  const bool is_valid =
+      std::all_of(new_ops.begin(), new_ops.end(),
+                  [validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
+                    return validate_op_config(op_wrapper);
+                  });
+  if (is_valid) {
+    // Adjust the name to avoid a name collision in the Qnn JSON dump.
+    for (size_t i = 0; i < new_ops.size(); ++i) {
+      new_ops[i].AddSuffixToName(absl::StrCat("_qcg2g_", i));
+    }
+    // Replace the matched pattern with a newly generated subgraph.
+    size_t step_size = new_ops.size();
+    ops.insert(ops.begin() + start_index + pattern_size,
+               std::make_move_iterator(new_ops.begin()),
+               std::make_move_iterator(new_ops.end()));
+    ops.erase(ops.begin() + start_index,
+              ops.begin() + start_index + pattern_size);
+    QNN_LOG_INFO("[G2G] FastVLM decode optimization done.");
+    return step_size;
+  }
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+
 namespace {
 
 bool OptimizeMHATinyGemmaPrefill(

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
@@ -42,6 +42,11 @@ size_t OptimizeMHAFastVlmPrefill(
     std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
     size_t pattern_size);
 
+size_t OptimizeMHAFastVlmDecode(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
 size_t OptimizeMHATinyGemmaPrefillPatternWithGlobalMask(
     std::function<bool(OpWrapper&)> validate_op_config,
     std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -206,6 +206,7 @@ class TensorWrapper final {
 };
 
 using TensorWrapperRef = std::reference_wrapper<TensorWrapper>;
+using ConstTensorWrapperRef = std::reference_wrapper<const TensorWrapper>;
 
 // Get the Qnn_DataType_t associated with given C++ type.
 template <typename T>


### PR DESCRIPTION
## TEST
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 36.5s
```

```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (1 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 31 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (767 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (721 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (794 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1403 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (720 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (397 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1908 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (26 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test


SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (418 ms total)
[  PASSED  ] 2 tests.

```